### PR TITLE
Second row created upon comfirmation of friendship

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -20,7 +20,7 @@ class PostsController < ApplicationController
   private
 
   def timeline_posts
-    @timeline_posts ||= Post.where(user: current_user.friends + [current_user.id]).ordered_by_most_recent.includes(:user)
+    @timeline_posts ||= Post.where(user: current_user.friends + [current_user.id]).ordered_by_most_recent
   end
 
   def post_params

--- a/app/models/friendship.rb
+++ b/app/models/friendship.rb
@@ -22,10 +22,9 @@ class Friendship < ApplicationRecord
   end
 
   def confirm_friend
-    self.update_attributes(confirmed: true)
-    Friendship.create!(friend_id: self.user_id,
-                    user_id: self.friend_id,
-                    confirmed: true)
+    update_attributes(confirmed: true)
+    Friendship.create!(friend_id: user_id,
+                       user_id: friend_id,
+                       confirmed: true)
   end
-  
 end

--- a/app/models/friendship.rb
+++ b/app/models/friendship.rb
@@ -20,4 +20,12 @@ class Friendship < ApplicationRecord
       Friendship.where(user_id: id1, friend_id: id2, confirmed: true)[0].id
     end
   end
+
+  def confirm_friend
+    self.update_attributes(confirmed: true)
+    Friendship.create!(friend_id: self.user_id,
+                    user_id: self.friend_id,
+                    confirmed: true)
+  end
+  
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,9 +12,9 @@ class User < ApplicationRecord
   has_many :friendships
   has_many :inverse_friendships, class_name: 'Friendship', foreign_key: 'friend_id'
 
-  has_many :confirmed_friendships, -> { where confirmed: true }, class_name: "Friendship"
+  has_many :confirmed_friendships, -> { where confirmed: true }, class_name: 'Friendship'
   has_many :friends, through: :confirmed_friendship
-  
+
   def friends
     friends_i_sent_invitation = Friendship.where(user_id: id, confirmed: true).pluck(:friend_id)
     friends_i_got_invitation = Friendship.where(friend_id: id, confirmed: true).pluck(:user_id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,19 +12,14 @@ class User < ApplicationRecord
   has_many :friendships
   has_many :inverse_friendships, class_name: 'Friendship', foreign_key: 'friend_id'
 
+  has_many :confirmed_friendships, -> { where confirmed: true }, class_name: "Friendship"
+  has_many :friends, through: :confirmed_friendship
+  
   def friends
     friends_i_sent_invitation = Friendship.where(user_id: id, confirmed: true).pluck(:friend_id)
     friends_i_got_invitation = Friendship.where(friend_id: id, confirmed: true).pluck(:user_id)
     ids = friends_i_sent_invitation + friends_i_got_invitation
     User.where(id: ids)
-  end
-
-  def friend_with?(user)
-    Friendship.confirmed_record?(id, user.id)
-  end
-
-  def send_invitation(user)
-    friendships.create(friend_id: user.id)
   end
 
   # Users who have yet to confirme friend requests


### PR DESCRIPTION
 Implement friendships with 2 rows for mutual friendship.
We did our best by implementing two rows for mutual friendship and followed what the TSE recommended but we keep getting an error that "There is no association for Comfirmed_friendship" so we had to maintain the friends' method so that we can continue with our project.
